### PR TITLE
fix typo

### DIFF
--- a/directory.html
+++ b/directory.html
@@ -146,7 +146,7 @@
           <tr>
             <td valign="top"><b>Researcher Inter Caetera</b><br>(Codename: "inter_caetera")</td>
             <td valign="top">
-              Central European Sector. Type Safe JavaS*ript Researcher, Containment Division.
+              Central European Sector. Type Safe JavaScript Researcher, Containment Division.
               <br><i><b>Institute Note:</b> Researcher's interests are suspected to drift towards LISP-based memetic
                 technologies, all such investigations should ONLY be conducted in Containment Room Lambda.</i>
             </td>


### PR DESCRIPTION
In the word "JavaScript" the letter "c" was erroneously replaced with an asterisk, this PR fixes this overshight.