### PR TITLE
Add Researcher Sam Pocino to the Personnel directory and fix incident report index

### DIFF
--- a/directory.html
+++ b/directory.html
@@ -183,6 +183,16 @@
             <td valign="top"><a href="https://x.com/scheminglunatic" target="_blank">X Profile</a></td>
           </tr>
           <tr>
+            <td valign="top"><b>Researcher Sam Pocino</b><br>(Codename: "sam_pocino")</td>
+            <td valign="top">
+              Junior Field Researcher, object containment division. Researching substructual typing, modalities, and
+              corecursion as potential cognitohazard mitigation strategies for the "OOP" parasitic memeplex.<br>
+              <i><b>Institute Note:</b> Subject exhibits a high tolerance for paradoxical logic, likely due to prior
+                exposure to memetic hazards in the field. Recommended for advanced containment training.</i>
+            </td>
+            <td valign="top"><a href="https://x.com/sampocino" target="_blank">X Profile</a></td>
+          </tr>
+          <tr>
             <td valign="top"><b>ARGUS System Daemon</b><br>(SYSTEM AI)</td>
             <td valign="top">
               <font color="#FF8C00"><b>STATUS: OPERATIONAL (POST-INFECTION)</b></font><br>

--- a/incidents.html
+++ b/incidents.html
@@ -23,6 +23,13 @@
 <p><b>Description:</b> This archive provides a central index of all documented memetic incidents and info-hazardous events investigated by the Institute. Review of these files requires appropriate cognitive shielding. Proceed with caution.</p>
 
 <table border="1" cellpadding="5" cellspacing="0" width="100%">
+  <tr bgcolor="#c0c0c0">
+    <th align="left">Date</th>
+    <th align="left">Item #</th>
+    <th align="left">Alias</th>
+    <th align="left">Object Class</th>
+    <th align="left">Report Link</th>
+  </tr>
   <tr>
     <td valign="top">25-AUG-2025</td>
     <td valign="top"><b>TS-UNS-666</b></td>
@@ -37,13 +44,6 @@
     <td valign="top">"Typefuckery Incident"</td>
     <td valign="top"><font color="#FF8C00"><b>Euclid</b></font></td>
     <td valign="top"><a href="incident-ts-vul-13.html">View Report</a></td>
-  </tr>
-  <tr bgcolor="#c0c0c0">
-    <th align="left">Date</th>
-    <th align="left">Item #</th>
-    <th align="left">Alias</th>
-    <th align="left">Object Class</th>
-    <th align="left">Report Link</th>
   </tr>
   <tr>
     <td valign="top">21-JUL-2025</td>


### PR DESCRIPTION
I have added the field researcher Sam Pocino to the index and fixed the position of the table header in the incident report index.

In recognition of the memetic anomaly on the incident report page, I will begin drafting an RFC for typed HTML.