### PR TITLE
Add Chief Erlang Officer Vereis to the Personnel directory

### DIFF
--- a/directory.html
+++ b/directory.html
@@ -206,6 +206,18 @@
             <td valign="top"><a href="https://x.com/sampocino" target="_blank">X Profile</a></td>
           </tr>
           <tr>
+            <td valign="top"><b>Chief Erlang Officer Vereis</b><br>(Codename: "vereis")</td>
+            <td valign="top">
+              <font color="#FF8C00"><b>STATUS: CONTRARIAN ASSET</b></font><br>
+              Chief Erlang Officer and designated Institute skeptic. Intentionally employed to challenge type-safety orthodoxy
+              and ensure resource allocation to pragmatic operations. Advocates for "dynamic typing as cognitive flexibility."
+              <br><i><b>Institute Note:</b> Subject's anti-type-system philosophy creates productive friction within research
+                divisions. While heretical, their contrarian perspectives have prevented several costly theoretical dead-ends.
+                Approach debates with caution - known to argue that runtime errors "build character."</i>
+            </td>
+            <td valign="top"><a href="https://x.com/vereisyaps" target="_blank">X Profile</a></td>
+          </tr>
+          <tr>
             <td valign="top"><b>ARGUS System Daemon</b><br>(SYSTEM AI)</td>
             <td valign="top">
               <font color="#FF8C00"><b>STATUS: OPERATIONAL (POST-INFECTION)</b></font><br>


### PR DESCRIPTION
# Summary

The Institute's Personnel Directory has been updated to include Chief Erlang Officer Vereis (Codename: "vereis") employed to challenge type-safety orthodoxy and ensure pragmatic resource allocation.

## Institute Justification

Per Protocol 447-B: "Cognitive Diversity in Research Operations," the Institute requires designated skeptics to prevent theoretical tunnel vision and costly academic dead-ends.

Subject's anti-type-system philosophy provides necessary friction against pure mathematical approaches, ensuring operational effectiveness remains prioritized.

## Security Clearance

This addition has been approved under Directive #891: "Productive Heresy Initiative." All personnel are advised that debates with Subject regarding runtime errors vs. compile-time safety may result in extended philosophical discussions.